### PR TITLE
Display action-ref warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@actions/core": "^1.6.0"
+      },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
@@ -16,7 +19,25 @@
         "husky": "^7.0.4",
         "prettier": "^2.5.1",
         "prettier-config-standard": "^4.0.0",
+        "proxyquire": "^2.1.3",
+        "sinon": "^13.0.1",
         "tap": "^15.1.6"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1042,6 +1063,41 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "sourcemap-codec": "1.4.8"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.0.tgz",
+      "integrity": "sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -2292,6 +2348,19 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2877,6 +2946,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -2924,6 +3002,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3208,6 +3292,12 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3295,6 +3385,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -3403,6 +3499,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3504,6 +3606,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3515,6 +3623,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -3826,6 +3947,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -3920,6 +4050,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "node_modules/psl": {
@@ -4249,6 +4390,54 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -6768,6 +6957,14 @@
         }
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6796,6 +6993,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -7165,6 +7371,22 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "requires": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@ampproject/remapping": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.2.tgz",
@@ -7931,6 +8153,41 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "sourcemap-codec": "1.4.8"
       }
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.0.tgz",
+      "integrity": "sha512-M8vapsv9qQupMdzrVzkn5rb9jG7aUTEPAZdMtME2PuBaefksFZVE2C1g4LBRTkF/k3nRDNbDc5tp5NFC1PEYxA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@tsconfig/node10": {
       "version": "1.0.8",
@@ -8883,6 +9140,16 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -9306,6 +9573,12 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -9337,6 +9610,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -9564,6 +9843,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -9633,6 +9918,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.merge": {
@@ -9710,6 +10001,12 @@
         }
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9784,6 +10081,12 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9795,6 +10098,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-preload": {
       "version": "0.2.1",
@@ -10033,6 +10349,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -10100,6 +10425,17 @@
       "dev": true,
       "requires": {
         "fromentries": "^1.2.0"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "psl": {
@@ -10351,6 +10687,43 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
+    },
+    "sinon": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.5.7",
@@ -11963,6 +12336,11 @@
         "yn": "3.1.1"
       }
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -11986,6 +12364,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,14 @@
     "husky": "^7.0.4",
     "prettier": "^2.5.1",
     "prettier-config-standard": "^4.0.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^13.0.1",
     "tap": "^15.1.6"
   },
   "lint-staged": {
     "*.{js}": "eslint --cache --fix"
+  },
+  "dependencies": {
+    "@actions/core": "^1.6.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,27 @@
 'use strict'
 
+const core = require('@actions/core')
+
 /**
- * Returns warning message if the action reference is pinned to master/main
+ * Displays warning message if the action reference is pinned to master/main
  *
  * @param     repoName          Full name of the repo (owner/repo-name)
- * @return   { String | null }  Warning to be emitted
  */
-function getActionRefWarning(repoName) {
-  if (!repoName) return null
-
+function getActionRefWarning(repoName = 'Repository') {
   const actionRef = process.env.GITHUB_ACTION_REF
 
   if (actionRef === 'main' || actionRef === 'master') {
-    return (
+    core.warning(
       `${repoName} is pinned at HEAD. We strongly ` +
-      `advise against pinning to "@master" as it may be unstable. Please ` +
-      `update your GitHub Action YAML from:\n\n` +
-      `    uses: '${repoName}@master'\n\n` +
-      `to:\n\n` +
-      `    uses: '${repoName}@<release/tag version>'\n\n` +
-      `Alternatively, you can pin to any git tag or git SHA in the ` +
-      `repository.`
+        `advise against pinning to "@master" as it may be unstable. Please ` +
+        `update your GitHub Action YAML from:\n\n` +
+        `    uses: '${repoName}@${actionRef}'\n\n` +
+        `to:\n\n` +
+        `    uses: '${repoName}@<release/tag version>'\n\n` +
+        `Alternatively, you can pin to any git tag or git SHA in the ` +
+        `repository.`
     )
   }
-  return null
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const core = require('@actions/core')
  *
  * @param     repoName          Full name of the repo (owner/repo-name)
  */
-function displayActionRefWarning(repoName = 'Repository') {
+function logActionRefWarning(repoName = 'Repository') {
   const actionRef = process.env.GITHUB_ACTION_REF
 
   if (actionRef === 'main' || actionRef === 'master') {
@@ -25,5 +25,5 @@ function displayActionRefWarning(repoName = 'Repository') {
 }
 
 module.exports = {
-  displayActionRefWarning
+  logActionRefWarning
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const core = require('@actions/core')
  *
  * @param     repoName          Full name of the repo (owner/repo-name)
  */
-function getActionRefWarning(repoName = 'Repository') {
+function displayActionRefWarning(repoName = 'Repository') {
   const actionRef = process.env.GITHUB_ACTION_REF
 
   if (actionRef === 'main' || actionRef === 'master') {
@@ -25,5 +25,5 @@ function getActionRefWarning(repoName = 'Repository') {
 }
 
 module.exports = {
-  getActionRefWarning
+  displayActionRefWarning
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,7 +29,7 @@ test('should return warning if actionRef is master', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'master'
-  toolkit.getActionRefWarning('nearform/test-repo')
+  toolkit.displayActionRefWarning('nearform/test-repo')
 
   match(warningStub.args[0], /nearform\/test-repo is pinned at HEAD/)
 })
@@ -48,7 +48,7 @@ test('should return warning if actionRef is main', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'main'
-  toolkit.getActionRefWarning('nearform/test-repo')
+  toolkit.displayActionRefWarning('nearform/test-repo')
 
   match(warningStub.args[0], /nearform\/test-repo is pinned at HEAD/)
 })
@@ -67,7 +67,7 @@ test('should return null if actionRef is not main or master', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'feat-test'
-  toolkit.getActionRefWarning('nearform/test-repo')
+  toolkit.displayActionRefWarning('nearform/test-repo')
 
   equal(warningStub.called, false)
 })
@@ -81,7 +81,7 @@ test('should print generic warning if invalid repoName', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'main'
-  toolkit.getActionRefWarning()
+  toolkit.displayActionRefWarning()
 
   match(warningStub.args[0], /Repository is pinned at HEAD/)
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,7 +53,7 @@ test('should return warning if actionRef is main', async ({
   match(warningStub.args[0], /nearform\/test-repo is pinned at HEAD/)
 })
 
-test('should return null if actionRef is not main or master', async ({
+test('should not print warning if actionRef is not main or master', async ({
   equal,
   plan,
   teardown

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,13 +15,7 @@ const setup = () => {
   return { toolkit, warningStub }
 }
 
-test('should return warning if actionRef is master', async ({
-  match,
-  plan,
-  teardown
-}) => {
-  plan(1)
-
+test('should return warning if actionRef is master', async ({ teardown }) => {
   teardown(() => {
     process.env.GITHUB_ACTION_REF = undefined
   })
@@ -29,18 +23,15 @@ test('should return warning if actionRef is master', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'master'
-  toolkit.displayActionRefWarning('nearform/test-repo')
+  toolkit.logActionRefWarning('nearform/test-repo')
 
-  match(warningStub.args[0], /nearform\/test-repo is pinned at HEAD/)
+  sinon.assert.calledOnceWithMatch(
+    warningStub,
+    /nearform\/test-repo is pinned at HEAD/
+  )
 })
 
-test('should return warning if actionRef is main', async ({
-  match,
-  plan,
-  teardown
-}) => {
-  plan(1)
-
+test('should return warning if actionRef is main', async ({ teardown }) => {
   teardown(() => {
     process.env.GITHUB_ACTION_REF = undefined
   })
@@ -48,18 +39,17 @@ test('should return warning if actionRef is main', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'main'
-  toolkit.displayActionRefWarning('nearform/test-repo')
+  toolkit.logActionRefWarning('nearform/test-repo')
 
-  match(warningStub.args[0], /nearform\/test-repo is pinned at HEAD/)
+  sinon.assert.calledOnceWithMatch(
+    warningStub,
+    /nearform\/test-repo is pinned at HEAD/
+  )
 })
 
 test('should not print warning if actionRef is not main or master', async ({
-  equal,
-  plan,
   teardown
 }) => {
-  plan(1)
-
   teardown(() => {
     process.env.GITHUB_ACTION_REF = undefined
   })
@@ -67,21 +57,16 @@ test('should not print warning if actionRef is not main or master', async ({
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'feat-test'
-  toolkit.displayActionRefWarning('nearform/test-repo')
+  toolkit.logActionRefWarning('nearform/test-repo')
 
-  equal(warningStub.called, false)
+  sinon.assert.notCalled(warningStub)
 })
 
-test('should print generic warning if invalid repoName', async ({
-  plan,
-  match
-}) => {
-  plan(1)
-
+test('should print generic warning if invalid repoName', async () => {
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'main'
-  toolkit.displayActionRefWarning()
+  toolkit.logActionRefWarning()
 
-  match(warningStub.args[0], /Repository is pinned at HEAD/)
+  sinon.assert.calledOnceWithMatch(warningStub, /Repository is pinned at HEAD/)
 })


### PR DESCRIPTION
After this change the warning is emitted by the actions-toolkit instead of passing it back to the repo using this toolkit. This way we can get rid of an extra conditional step in the action repo. Tests updated

Closes #2 