### PR TITLE
Master to changed to action-ref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function logActionRefWarning() {
   if (actionRef === 'main' || actionRef === 'master') {
     core.warning(
       `${repoName} is pinned at HEAD. We strongly ` +
-        `advise against pinning to "@master" as it may be unstable. Please ` +
+        `advise against pinning to "@${actionRef}" as it may be unstable. Please ` +
         `update your GitHub Action YAML from:\n\n` +
         `    uses: '${repoName}@${actionRef}'\n\n` +
         `to:\n\n` +


### PR DESCRIPTION
Minor fix which changes hardcoded `master` branch to the actual action-ref

Closes #9 