### PR TITLE
feat: ability to deal with composite actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const core = require('@actions/core')
+const newOrg = 'nearform-actions'
+const oldOrg = 'nearform'
 
 /**
  * Displays warning message if the action reference is pinned to master/main
@@ -28,19 +30,31 @@ function logActionRefWarning() {
  */
 function logRepoWarning() {
   const actionRepo = process.env.GITHUB_ACTION_REPOSITORY
-  const [repoOrg, repoName] = actionRepo.split('/')
-  const newOrg = 'nearform-actions'
+  const action = process.env.GITHUB_ACTION
 
-  if (repoOrg != newOrg) {
-    core.warning(
-      `The '${repoName}' action, no longer exists under the '${repoOrg}' organisation.\n` +
-        `Please update it to '${newOrg}', you can do this\n` +
-        `by updating your Github Workflow file from:\n\n` +
-        `    uses: '${repoOrg}/${repoName}'\n\n` +
-        `to:\n\n` +
-        `    uses: '${newOrg}/${repoName}'\n\n`
-    )
+  const [repoOrg, repoName] = actionRepo.split('/')
+  let parentActionOrg, parentActionRepo
+  ;[, parentActionOrg] = action.match(/__(.*)_/)
+  parentActionOrg = parentActionOrg.replace('_', '-')
+  ;[parentActionRepo] = action.match(/([^_]+$)/)
+
+  if (repoOrg === oldOrg || parentActionOrg === oldOrg) {
+    return warning(repoOrg === oldOrg ? repoName : parentActionRepo)
   }
+}
+
+/**
+ * Simple function to avoid the repetition of the message
+ */
+function warning(repoName) {
+  return core.warning(
+    `The '${repoName}' action, no longer exists under the '${oldOrg}' organisation.\n` +
+      `Please update it to '${newOrg}', you can do this\n` +
+      `by updating your Github Workflow file from:\n\n` +
+      `    uses: '${oldOrg}/${repoName}'\n\n` +
+      `to:\n\n` +
+      `    uses: '${newOrg}/${repoName}'\n\n`
+  )
 }
 
 module.exports = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,18 +69,20 @@ test('should not print warning if actionRef is not main or master', async ({
   sinon.assert.notCalled(warningStub)
 })
 
-test("should print a warning if repoName is not under the 'nearform-actions' organisation", async ({
+test("should print a warning if the reusable workflow is not under the 'nearform-actions' organisation", async ({
   teardown
 }) => {
   teardown(() => {
     process.env.GITHUB_ACTION_REF = undefined
     process.env.GITHUB_ACTION_REPOSITORY = undefined
+    process.env.GITHUB_ACTION = undefined
   })
 
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'main'
   process.env.GITHUB_ACTION_REPOSITORY = 'nearform/test-repo'
+  process.env.GITHUB_ACTION = '__nearform_test-repo'
   toolkit.logRepoWarning()
 
   sinon.assert.calledOnceWithMatch(
@@ -89,18 +91,61 @@ test("should print a warning if repoName is not under the 'nearform-actions' org
   )
 })
 
-test("should not print a warning if repoName is under the 'nearform-actions' organisation", async ({
+test("should not print a warning if the reusable workflow is under the 'nearform-actions' organisation", async ({
   teardown
 }) => {
   teardown(() => {
     process.env.GITHUB_ACTION_REF = undefined
     process.env.GITHUB_ACTION_REPOSITORY = undefined
+    process.env.GITHUB_ACTION = undefined
   })
 
   const { toolkit, warningStub } = setup()
 
   process.env.GITHUB_ACTION_REF = 'main'
   process.env.GITHUB_ACTION_REPOSITORY = 'nearform-actions/test-repo'
+  process.env.GITHUB_ACTION = '__nearform_actions_test-repo'
+  toolkit.logRepoWarning()
+
+  sinon.assert.notCalled(warningStub)
+})
+
+test("should print a warning if the composite action is not under the 'nearform-actions' organisation", async ({
+  teardown
+}) => {
+  teardown(() => {
+    process.env.GITHUB_ACTION_REF = undefined
+    process.env.GITHUB_ACTION_REPOSITORY = undefined
+    process.env.GITHUB_ACTION = undefined
+  })
+
+  const { toolkit, warningStub } = setup()
+
+  process.env.GITHUB_ACTION_REF = 'main'
+  process.env.GITHUB_ACTION_REPOSITORY = 'actions/github'
+  process.env.GITHUB_ACTION = '__nearform_composite-action'
+  toolkit.logRepoWarning()
+
+  sinon.assert.calledOnceWithMatch(
+    warningStub,
+    /The 'composite-action' action, no longer exists under the 'nearform' organisation./
+  )
+})
+
+test("should not print a warning if the composite action is under the 'nearform-actions' organisation", async ({
+  teardown
+}) => {
+  teardown(() => {
+    process.env.GITHUB_ACTION_REF = undefined
+    process.env.GITHUB_ACTION_REPOSITORY = undefined
+    process.env.GITHUB_ACTION = undefined
+  })
+
+  const { toolkit, warningStub } = setup()
+
+  process.env.GITHUB_ACTION_REF = 'main'
+  process.env.GITHUB_ACTION_REPOSITORY = 'actions/github'
+  process.env.GITHUB_ACTION = '__nearform_actions_composite-action'
   toolkit.logRepoWarning()
 
   sinon.assert.notCalled(warningStub)


### PR DESCRIPTION
This deals with the scenario where an action might be a composite action.

Historically the root action would not be used therefore errors would be thrown on actions such as: `actions/checkout`, this behaviour has now been updated to allow for this and use the parent action instead.

Fixes #121 