### PR TITLE
Simpler handling for composite actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,16 +30,18 @@ function logActionRefWarning() {
  */
 function logRepoWarning() {
   const actionRepo = process.env.GITHUB_ACTION_REPOSITORY
-  const action = process.env.GITHUB_ACTION
+  const actionPath = process.env.GITHUB_ACTION_PATH
+
+  // Handle composite actions
+  if (actionPath && actionPath.includes('/nearform/')) {
+    const actionRepoName = actionPath.split('/nearform/')[1]
+    return warning(actionRepoName)
+  }
 
   const [repoOrg, repoName] = actionRepo.split('/')
-  let parentActionOrg, parentActionRepo
-  ;[, parentActionOrg] = action.match(/__(.*)_/)
-  parentActionOrg = parentActionOrg.replace('_', '-')
-  ;[parentActionRepo] = action.match(/([^_]+$)/)
 
-  if (repoOrg === oldOrg || parentActionOrg === oldOrg) {
-    return warning(repoOrg === oldOrg ? repoName : parentActionRepo)
+  if (repoOrg === oldOrg) {
+    return warning(repoName)
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -123,12 +123,13 @@ test("should print a warning if the composite action is not under the 'nearform-
 
   process.env.GITHUB_ACTION_REF = 'main'
   process.env.GITHUB_ACTION_REPOSITORY = 'actions/github'
-  process.env.GITHUB_ACTION = '__nearform_composite-action'
+  process.env.GITHUB_ACTION_PATH =
+    '/home/runner/work/_actions/nearform/name-of-action-repo'
   toolkit.logRepoWarning()
 
   sinon.assert.calledOnceWithMatch(
     warningStub,
-    /The 'composite-action' action, no longer exists under the 'nearform' organisation./
+    /The 'name-of-action-repo' action, no longer exists under the 'nearform' organisation./
   )
 })
 
@@ -145,7 +146,8 @@ test("should not print a warning if the composite action is under the 'nearform-
 
   process.env.GITHUB_ACTION_REF = 'main'
   process.env.GITHUB_ACTION_REPOSITORY = 'actions/github'
-  process.env.GITHUB_ACTION = '__nearform_actions_composite-action'
+  process.env.GITHUB_ACTION_PATH =
+    '/home/runner/work/_actions/nearform-actions/name-of-action-repo'
   toolkit.logRepoWarning()
 
   sinon.assert.notCalled(warningStub)


### PR DESCRIPTION
Closes #130 

Hopefully resolves some problems with the previous approach by using `GITHUB_ACTION_PATH` to handle composite actions