### PR TITLE
Include version in warning with correct syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,15 @@ function logRepoWarning() {
 
   // Handle composite actions
   if (actionPath && actionPath.includes('/nearform/')) {
-    const actionRepoName = actionPath.split('/nearform/')[1].split('/')[0]
-    return warning(actionRepoName)
+    const [actionRepoName, actionRepoVersion] = actionPath
+      .split('/nearform/')[1]
+      .split('/')
+
+    return warning(
+      actionRepoVersion
+        ? `${actionRepoName}@${actionRepoVersion}`
+        : actionRepoName
+    )
   }
 
   const [repoOrg, repoName] = actionRepo.split('/')

--- a/src/index.js
+++ b/src/index.js
@@ -38,11 +38,7 @@ function logRepoWarning() {
       .split('/nearform/')[1]
       .split('/')
 
-    return warning(
-      actionRepoVersion
-        ? `${actionRepoName}@${actionRepoVersion}`
-        : actionRepoName
-    )
+    return warning(actionRepoName, actionRepoVersion)
   }
 
   const [repoOrg, repoName] = actionRepo.split('/')
@@ -55,14 +51,15 @@ function logRepoWarning() {
 /**
  * Simple function to avoid the repetition of the message
  */
-function warning(repoName) {
+function warning(repoName, repoVersion) {
+  const nameWithVersion = repoVersion ? `${repoName}@${repoVersion}` : repoName
   return core.warning(
     `The '${repoName}' action, no longer exists under the '${oldOrg}' organisation.\n` +
       `Please update it to '${newOrg}', you can do this\n` +
       `by updating your Github Workflow file from:\n\n` +
-      `    uses: '${oldOrg}/${repoName}'\n\n` +
+      `    uses: '${oldOrg}/${nameWithVersion}'\n\n` +
       `to:\n\n` +
-      `    uses: '${newOrg}/${repoName}'\n\n`
+      `    uses: '${newOrg}/${nameWithVersion}'\n\n`
   )
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -124,12 +124,35 @@ test("should print a warning if the composite action is not under the 'nearform-
   process.env.GITHUB_ACTION_REF = 'main'
   process.env.GITHUB_ACTION_REPOSITORY = 'actions/github'
   process.env.GITHUB_ACTION_PATH =
-    '/home/runner/work/_actions/nearform/name-of-action-repo/v1'
+    '/home/runner/work/_actions/nearform/name-of-action-repo'
   toolkit.logRepoWarning()
 
   sinon.assert.calledOnceWithMatch(
     warningStub,
     /The 'name-of-action-repo' action, no longer exists under the 'nearform' organisation./
+  )
+})
+
+test('should include version number in warning if in path', async ({
+  teardown
+}) => {
+  teardown(() => {
+    process.env.GITHUB_ACTION_REF = undefined
+    process.env.GITHUB_ACTION_REPOSITORY = undefined
+    process.env.GITHUB_ACTION_PATH = undefined
+  })
+
+  const { toolkit, warningStub } = setup()
+
+  process.env.GITHUB_ACTION_REF = 'main'
+  process.env.GITHUB_ACTION_REPOSITORY = 'actions/github'
+  process.env.GITHUB_ACTION_PATH =
+    '/home/runner/work/_actions/nearform/name-of-action-repo/v1'
+  toolkit.logRepoWarning()
+
+  sinon.assert.calledOnceWithMatch(
+    warningStub,
+    /The 'name-of-action-repo@v1' action, no longer exists under the 'nearform' organisation./
   )
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -129,7 +129,7 @@ test("should print a warning if the composite action is not under the 'nearform-
 
   sinon.assert.calledOnceWithMatch(
     warningStub,
-    /The 'name-of-action-repo' action, no longer exists under the 'nearform' organisation./
+    /The 'name-of-action-repo' action, no longer exists under the 'nearform' organisation.(\n.*)+uses: 'nearform-actions\/name-of-action-repo'/
   )
 })
 
@@ -152,7 +152,7 @@ test('should include version number in warning if in path', async ({
 
   sinon.assert.calledOnceWithMatch(
     warningStub,
-    /The 'name-of-action-repo@v1' action, no longer exists under the 'nearform' organisation./
+    /The 'name-of-action-repo' action, no longer exists under the 'nearform' organisation.(\n.*)+uses: 'nearform-actions\/name-of-action-repo@v1'/
   )
 })
 


### PR DESCRIPTION
Closes #136

Includes the version in warnings for composite actions, where present.