### PR TITLE
chore(deps): bump minor + patch dependencies (verified, tests green)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   },
   "homepage": "https://github.com/nearform/actions-toolkit#readme",
   "devDependencies": {
-    "@commitlint/cli": "^21.1.0",
-    "@commitlint/config-conventional": "^21.1.0",
-    "eslint": "^8.57.0",
+    "@commitlint/cli": "^21.2.0",
+    "@commitlint/config-conventional": "^21.2.0",
+    "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "husky": "^9.1.7",
-    "prettier": "^3.9.3",
+    "prettier": "^3.9.4",
     "prettier-config-standard": "^7.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^22.0.0"
@@ -42,6 +42,6 @@
     "*.{js}": "eslint --cache --fix"
   },
   "dependencies": {
-    "@actions/core": "^2.0.2"
+    "@actions/core": "^2.0.3"
   }
 }


### PR DESCRIPTION
Batches available **minor + patch** upgrades (5 packages, no majors) into one PR. Baseline `npm test` green **before**, and green **after** the bump. All available minor/patch upgrades. Companion PR adds dependabot minor/patch grouping. For human review + merge — not merging anything.